### PR TITLE
lowercase params for GetVocabIRI

### DIFF
--- a/Assets/GBLxAPI/Scripts/Utils/GBLUtils.cs
+++ b/Assets/GBLxAPI/Scripts/Utils/GBLUtils.cs
@@ -46,7 +46,7 @@ namespace DIG.GBLXAPI
 		{
 			try
 			{
-				return (string)GBLXAPI.StandardsJson[type][name]["id"];
+				return (string)GBLXAPI.StandardsJson[type.ToLower()][name.ToLower()]["id"];
 			}
 			catch (NullReferenceException)
 			{


### PR DESCRIPTION
type and name variables to lowercase for GetVocabIRI method as in activity and verb methods